### PR TITLE
fix: update demo link text for vanilla-js card

### DIFF
--- a/site/src/pages/web/Home.js
+++ b/site/src/pages/web/Home.js
@@ -67,7 +67,7 @@ export default () => (
               }
             },
             {
-              text: 'Docs',
+              text: 'Demo',
               link:
                 'https://codesandbox.io/s/github/appbaseio/searchbase/tree/master/packages/searchbox/examples/searchbar-with-style'
             }


### PR DESCRIPTION
Card says `Docs` it should be instead `Demo`
![image](https://user-images.githubusercontent.com/22376783/94915420-7f440080-04ca-11eb-8327-ee85cc225050.png)
