### PR TITLE
fix(native): autosuggest prop not working correctly

### DIFF
--- a/packages/native/src/components/SearchBox/index.js
+++ b/packages/native/src/components/SearchBox/index.js
@@ -302,6 +302,9 @@ class SearchBox extends React.Component {
         if (value && triggerDefaultQuery) {
           debounceFunc(this.triggerDefaultQuery, debounce);
         }
+        if (!autosuggest) {
+          debounceFunc(this.triggerCustomQuery, debounce);
+        }
         if (rest.triggerCustomQuery) {
           this.triggerCustomQuery();
         }
@@ -312,6 +315,9 @@ class SearchBox extends React.Component {
           triggerDefaultQuery: !!value && triggerDefaultQuery,
           stateChanges: true
         });
+        if (!autosuggest) {
+          this.triggerCustomQuery();
+        }
       }
     }
   };


### PR DESCRIPTION
- Issue Type - Bug

- Notion Link - https://www.notion.so/appbase/Searchbox-Fix-autosuggest-property-159e39a529004485b286845fc4ac3a22

- Description - Passing false to the autosuggest prop was still triggering the default query and showing the suggestions list.

- Fixes -
-> Don't trigger defaultQuery when autosuggest is false.
-> Don't fetch recentSearches when autosuggest is false.
-> Don't display suggestions when autosuggest is false.
-> When autosuggest is false then results should get updated on each keystroke.
-> Debounce should work as expected.

- Demo -
https://www.loom.com/share/f76ab6307f1845fb90229646d0def5d5