### PR TITLE
fix: predictivesuggestions in searchbase

### DIFF
--- a/packages/searchbase/src/utils.js
+++ b/packages/searchbase/src/utils.js
@@ -348,11 +348,12 @@ export const getSuggestions = (
   };
 
   if (enablePredictiveSuggestions) {
-    return getPredictiveSuggestions({
-      suggestions: suggestionsList,
-      currentValue: value,
+    let results = getPredictiveSuggestions({
+      predictiveSuggestions: suggestionsList,
+      currentValuePredictive: value,
       wordsToShowAfterHighlight: true
     });
+    return results;
   }
   return suggestionsList;
 };


### PR DESCRIPTION
- Issue Type - Bug

- Description - The named parameters and the arguments passed to getPredictiveSuggestions function differed that caused this bug, I have updated it.

- video -  
https://www.loom.com/share/d9d9bdbe8f134e3a91b9f9bd2240b32c