### PR TITLE
isHotkeyCombinationUsed helper method working for first focusshortcuts only

### DIFF
--- a/packages/react-searchbox/src/utils/helper.js
+++ b/packages/react-searchbox/src/utils/helper.js
@@ -115,7 +115,7 @@ export function isHotkeyCombination(hotkey) {
 // parse focusshortcuts array for key combinations
 export function isHotkeyCombinationUsed(focusShortcuts) {
   for (let index = 0; index < focusShortcuts.length; index += 1) {
-    if (isHotkeyCombination(focusShortcuts[0])) {
+    if (isHotkeyCombination(focusShortcuts[index])) {
       return true;
     }
   }


### PR DESCRIPTION
**Issue Type** - Bug

**Description** -  The helper method was just checking the first shortcut in the array of focusShortcuts prop due to hardcoded index value passed within the for-loop.

<img width="571" alt="Screenshot 2021-05-15 at 4 23 59 PM" src="https://user-images.githubusercontent.com/57627350/118357935-1eb98d80-b59a-11eb-9246-81b012acff5f.png">
