### PR TITLE
Feat/support searchbox focus - Vue-SearchBox

### DIFF
--- a/packages/react-searchbox/src/components/SearchBox.js
+++ b/packages/react-searchbox/src/components/SearchBox.js
@@ -76,7 +76,8 @@ class SearchBox extends React.Component {
     if (!isEmpty(focusShortcuts)) {
       this.hotKeyCombinationsUsed = isHotkeyCombinationUsed(focusShortcuts);
       if (this.hotKeyCombinationsUsed) {
-        import('hotkeys-js')
+        const moduleName = 'hotkeys-js';
+        import(moduleName)
           .then(module => {
             this.hotkeys = module.default;
           })

--- a/packages/vue-searchbox/examples/demo/src/App.vue
+++ b/packages/vue-searchbox/examples/demo/src/App.vue
@@ -51,10 +51,7 @@
           :enablePopularSuggestions="true"
           :enableRecentSearches="true"
           iconPosition="left"
-          :focusShortcuts="['b', 'ctrl+y']"
         >
-          <h1 slot="addonBefore">Hi</h1>
-          <img slot="addonAfter" src="https://picsum.photos/20/30" />
         </search-box>
         <div class="row">
           <div class="col">

--- a/packages/vue-searchbox/examples/demo/src/App.vue
+++ b/packages/vue-searchbox/examples/demo/src/App.vue
@@ -51,7 +51,11 @@
           :enablePopularSuggestions="true"
           :enableRecentSearches="true"
           iconPosition="left"
-        />
+          :focusShortcuts="['b', 'ctrl+y']"
+        >
+          <h1 slot="addonBefore">Hi</h1>
+          <img slot="addonAfter" src="https://picsum.photos/20/30" />
+        </search-box>
         <div class="row">
           <div class="col">
             <search-component

--- a/packages/vue-searchbox/examples/demo/src/App.vue
+++ b/packages/vue-searchbox/examples/demo/src/App.vue
@@ -51,8 +51,7 @@
           :enablePopularSuggestions="true"
           :enableRecentSearches="true"
           iconPosition="left"
-        >
-        </search-box>
+        />
         <div class="row">
           <div class="col">
             <search-component

--- a/packages/vue-searchbox/package.json
+++ b/packages/vue-searchbox/package.json
@@ -39,7 +39,8 @@
         "vue-types": "^1.6.0"
     },
     "peerDependencies": {
-        "vue": "^2.6.10"
+        "vue": "^2.6.10",
+        "hotkeys-js": "^3.8.5"
     },
     "devDependencies": {
         "@babel/core": "^7.6.4",

--- a/packages/vue-searchbox/src/components/SearchBox.jsx
+++ b/packages/vue-searchbox/src/components/SearchBox.jsx
@@ -335,7 +335,6 @@ const SearchBox = {
 
 			return null;
 		},
-
 		renderInputAddonAfter() {
 			const { addonAfter } = this.$scopedSlots;
 			if (addonAfter) {
@@ -776,43 +775,49 @@ const SearchBox = {
 					/>
 				) : (
 					<div class={suggestionsContainer}>
-						<Input
-							ref="searchInputField"
-							class={getClassName(innerClass, 'input') || ''}
-							placeholder={placeholder}
-							autoFocus={autoFocus}
-							{...{
-								on: {
-									blur: e => {
-										this.$emit('blur', e);
-									},
-									keypress: e => {
-										this.$emit('keyPress', e);
-									},
-									input: this.onInputChange,
-									focus: e => {
-										this.$emit('focus', e);
-									},
-									keydown: e => {
-										this.$emit('keyDown', e);
-									},
-									keyup: e => {
-										this.$emit('keyUp', e);
-									}
-								}
-							}}
-							{...{
-								domProps: {
-									autofocus: autoFocus,
-									value: instanceValue || ''
-								}
-							}}
-							iconPosition={iconPosition}
-							showIcon={showIcon}
-							showClear={showClear}
-							innerRef={innerRef}
-						/>
-						{this.renderIcons()}
+						<InputGroup>
+							{this.renderInputAddonBefore()}
+							<InputWrapper>
+								<Input
+									ref="searchInputField"
+									class={getClassName(innerClass, 'input') || ''}
+									placeholder={placeholder}
+									autoFocus={autoFocus}
+									{...{
+										on: {
+											blur: e => {
+												this.$emit('blur', e);
+											},
+											keypress: e => {
+												this.$emit('keyPress', e);
+											},
+											input: this.onInputChange,
+											focus: e => {
+												this.$emit('focus', e);
+											},
+											keydown: e => {
+												this.$emit('keyDown', e);
+											},
+											keyup: e => {
+												this.$emit('keyUp', e);
+											}
+										}
+									}}
+									{...{
+										domProps: {
+											autofocus: autoFocus,
+											value: instanceValue || ''
+										}
+									}}
+									iconPosition={iconPosition}
+									showIcon={showIcon}
+									showClear={showClear}
+									innerRef={innerRef}
+								/>
+								{this.renderIcons()}
+							</InputWrapper>
+							{this.renderInputAddonAfter()}
+						</InputGroup>
 					</div>
 				)}
 			</div>

--- a/packages/vue-searchbox/src/components/SearchBox.jsx
+++ b/packages/vue-searchbox/src/components/SearchBox.jsx
@@ -148,7 +148,8 @@ const SearchBox = {
 		if (!isEmpty(focusShortcuts)) {
 			this.hotKeyCombinationsUsed = isHotkeyCombinationUsed(focusShortcuts);
 			if (this.hotKeyCombinationsUsed) {
-				import('hotkeys-js')
+				const moduleName = 'hotkeys-js';
+				import(moduleName)
 					.then(module => {
 						this.hotkeys = module.default;
 					}) // eslint-disable-next-line no-unused-vars

--- a/packages/vue-searchbox/src/components/SearchBox.jsx
+++ b/packages/vue-searchbox/src/components/SearchBox.jsx
@@ -1,6 +1,9 @@
 import VueTypes from 'vue-types';
 import SearchComponent from './SearchComponent.jsx';
 import { types } from '../utils/types';
+import InputGroup from '../styles/InputGroup';
+import InputWrapper from '../styles/InputWrapper';
+import InputAddon from '../styles/InputAddon';
 import Input from '../styles/Input';
 import DownShift from './DownShift.jsx';
 import {
@@ -10,7 +13,11 @@ import {
 	hasPopularSuggestionsRenderer,
 	getPopularSuggestionsComponent,
 	hasCustomRenderer,
-	getComponent
+	getComponent,
+	isEmpty,
+	isHotkeyCombinationUsed,
+	parseFocusShortcuts,
+	isNumeric
 } from '../utils/helper';
 import {
 	suggestions as suggestionsStyle,
@@ -108,24 +115,54 @@ const SearchBox = {
 		loading: VueTypes.bool,
 		error: VueTypes.any,
 		micStatus: VueTypes.string,
-		instanceValue: VueTypes.string
+		instanceValue: VueTypes.string,
+		//
+		focusShortcuts: VueTypes.focusShortcuts,
+		addonBefore: VueTypes.any,
+		addonAfter: VueTypes.any,
+		expandSuggestionsContainer: { default: true, type: Boolean }
 	},
 	data() {
 		this.state = {
 			isOpen: false
 		};
-		return this.state;
+		return {
+			...this.state,
+			hotkeys: undefined,
+			hotKeyCombinationsUsed: false
+		};
 	},
 	mounted() {
+		document.addEventListener('keydown', this.onKeyDown);
+		const { focusShortcuts } = this.$props;
 		if (this.aggregationField) {
 			console.warn(
-				'Warning(SearchBox): The `aggregationField` prop has been marked as deprecated, please use the `distinctField` prop instead.',
+				'Warning(SearchBox): The `aggregationField` prop has been marked as deprecated, please use the `distinctField` prop instead.'
 			);
 		}
-		if(this.enableRecentSearches && this.autosuggest) {
-			const { getRecentSearches } =  this.getComponentInstance();
+		if (this.enableRecentSearches && this.autosuggest) {
+			const { getRecentSearches } = this.getComponentInstance();
 			getRecentSearches();
 		}
+		// dynamically import hotkey-js
+		if (!isEmpty(focusShortcuts)) {
+			this.hotKeyCombinationsUsed = isHotkeyCombinationUsed(focusShortcuts);
+			if (this.hotKeyCombinationsUsed) {
+				import('hotkeys-js')
+					.then(module => {
+						this.hotkeys = module.default;
+					}) // eslint-disable-next-line no-unused-vars
+					.catch(err =>
+					// eslint-disable-next-line no-console
+						console.warn(
+							'Warning(SearchBox): The `hotkeys-js` library seems to be missing, it is required when using key combinations( eg: `ctrl+a`) in focusShortcuts prop.'
+						)
+					);
+			}
+		}
+	},
+	destroyed() {
+		document.removeEventListener('keydown', this.onKeyDown);
 	},
 	computed: {
 		hasCustomRenderer() {
@@ -161,7 +198,7 @@ const SearchBox = {
 			if (!instanceValue && defaultSuggestions) {
 				return defaultSuggestions;
 			}
-			if(!instanceValue) {
+			if (!instanceValue) {
 				return [];
 			}
 			const { suggestions } = this.getComponentInstance();
@@ -211,13 +248,13 @@ const SearchBox = {
 		},
 		triggerDefaultQuery() {
 			const componentInstance = this.getComponentInstance();
-			if(componentInstance) {
+			if (componentInstance) {
 				componentInstance.triggerDefaultQuery();
 			}
 		},
 		triggerCustomQuery() {
 			const componentInstance = this.getComponentInstance();
-			if(componentInstance) {
+			if (componentInstance) {
 				componentInstance.triggerCustomQuery();
 			}
 		},
@@ -225,7 +262,12 @@ const SearchBox = {
 			const { debounce } = this.$props;
 			this.isOpen = isOpen;
 			const componentInstance = this.getComponentInstance();
-			if (this.enableRecentSearches && !value && componentInstance.value && this.autosuggest) {
+			if (
+				this.enableRecentSearches
+        && !value
+        && componentInstance.value
+        && this.autosuggest
+			) {
 				componentInstance.getRecentSearches();
 			}
 			if (debounce > 0) {
@@ -234,17 +276,17 @@ const SearchBox = {
 					triggerCustomQuery: false,
 					stateChanges: true
 				});
-				if(this.autosuggest) {
+				if (this.autosuggest) {
 					debounceFunc(this.triggerDefaultQuery, debounce);
 				} else {
 					debounceFunc(this.triggerCustomQuery, debounce);
 				}
-				if(rest.triggerCustomQuery) {
+				if (rest.triggerCustomQuery) {
 					debounceFunc(this.triggerCustomQuery, debounce);
 				}
 			} else {
 				this.triggerSuggestionsQuery(value, rest.triggerCustomQuery);
-				if(!this.autosuggest) {
+				if (!this.autosuggest) {
 					this.triggerCustomQuery();
 				}
 			}
@@ -271,7 +313,11 @@ const SearchBox = {
 			// if a suggestion was selected, delegate the handling
 			// to suggestion handler
 			if (event.key === 'Enter' && highlightedIndex === null) {
-				this.setValue({ value: event.target.value, isOpen: false, triggerCustomQuery: true });
+				this.setValue({
+					value: event.target.value,
+					isOpen: false,
+					triggerCustomQuery: true
+				});
 				this.onValueSelectedHandler(event.target.value, causes.ENTER_PRESS);
 			}
 
@@ -280,6 +326,23 @@ const SearchBox = {
 		handleMicClick() {
 			const componentInstance = this.getComponentInstance();
 			componentInstance.onMicClick(null);
+		},
+		renderInputAddonBefore() {
+			const { addonBefore } = this.$scopedSlots;
+			if (addonBefore) {
+				return <InputAddon>{addonBefore()}</InputAddon>;
+			}
+
+			return null;
+		},
+
+		renderInputAddonAfter() {
+			const { addonAfter } = this.$scopedSlots;
+			if (addonAfter) {
+				return <InputAddon>{addonAfter()}</InputAddon>;
+			}
+
+			return null;
 		},
 		renderIcons() {
 			const {
@@ -375,7 +438,13 @@ const SearchBox = {
 			return highlightedIndex === index ? '#eee' : '#fff';
 		},
 		getComponent(downshiftProps = {}, isPopularSuggestionsRender = false) {
-			const { instanceValue, loading, error, results, recentSearches } = this.$props;
+			const {
+				instanceValue,
+				loading,
+				error,
+				results,
+				recentSearches
+			} = this.$props;
 			const popularSuggestionsList = this.getPopularSuggestionsList();
 			const suggestionsList = this.getSuggestionsList();
 			const data = {
@@ -405,6 +474,63 @@ const SearchBox = {
 				);
 			}
 			return getComponent(data, this);
+		},
+		focusSearchBox(event) {
+			const elt = event.target || event.srcElement;
+			const { tagName } = elt;
+			if (
+				elt.isContentEditable
+        || tagName === 'INPUT'
+        || tagName === 'SELECT'
+        || tagName === 'TEXTAREA'
+			) {
+				// already in an input
+				return;
+			}
+			this.$refs.searchInputField.focus();
+		},
+		onKeyDown(event) {
+			const { focusShortcuts = ['/'] } = this.$props;
+			if (isEmpty(focusShortcuts)) {
+				return;
+			}
+
+			// for hotkeys' combinations such as 'cmd+k', 'ctrl+shft+a', etc, we use hotkeys-js
+			if (this.hotKeyCombinationsUsed) {
+				console.log('hey there', this.hotKeyCombinationsUsed);
+				this.hotkeys(
+					parseFocusShortcuts(focusShortcuts).join(','), // eslint-disable-next-line no-unused-vars
+					/* eslint-disable no-shadow */ (event, handler) => {
+						// Prevent the default refresh event under WINDOWS system
+						event.preventDefault();
+
+						this.focusSearchBox(event);
+					}
+				);
+				return;
+			}
+			const shortcuts = focusShortcuts.map(key => {
+				if (typeof key === 'string') {
+					return isNumeric(key)
+						? parseInt(key, 10)
+						: key.toUpperCase().charCodeAt(0);
+				}
+				return key;
+			});
+
+			// the below algebraic expression is used to get the correct ascii code out of the e.which || e.keycode returned value
+			// since the keyboards doesn't understand ascii but scan codes and they differ for certain keys such as '/'
+			// stackoverflow ref: https://stackoverflow.com/a/29811987/10822996
+			const which = event.which || event.keyCode;
+			const chrCode = which - 48 * Math.floor(which / 48);
+			if (shortcuts.indexOf(which >= 96 ? chrCode : which) === -1) {
+				// not the right shortcut
+				return;
+			}
+			this.focusSearchBox(event);
+
+			event.stopPropagation();
+			event.preventDefault();
 		}
 	},
 	render() {
@@ -423,11 +549,15 @@ const SearchBox = {
 			size,
 			instanceValue,
 			recentSearches,
+			expandSuggestionsContainer
 		} = this.$props;
 		const { recentSearchesIcon, popularSearchesIcon } = this.$scopedSlots;
 		const suggestionsList = this.getSuggestionsList();
 		const popularSuggestionsList = this.getPopularSuggestionsList();
-		const hasSuggestions = defaultSuggestions && defaultSuggestions.length || recentSearches && recentSearches.length;
+		const hasSuggestions
+      = (defaultSuggestions && defaultSuggestions.length)
+      || (recentSearches && recentSearches.length);
+
 		return (
 			<div class={className}>
 				{title && (
@@ -447,185 +577,211 @@ const SearchBox = {
 								getItemEvents,
 								isOpen,
 								highlightedIndex
-							}) => (
-								<div class={suggestionsContainer}>
-									<Input
-										showIcon={showIcon}
-										showClear={showClear}
-										iconPosition={iconPosition}
-										class={getClassName(innerClass, 'input')}
-										placeholder={placeholder}
-										currentValue={instanceValue}
-										{...{
-											on: getInputEvents({
-												onInput: this.onInputChange,
-												onBlur: e => {
-													this.$emit('blur', e);
-												},
-												onFocus: this.handleFocus,
-												onKeyPress: e => {
-													this.$emit('keyPress', e);
-												},
-												onKeyDown: e => this.handleKeyDown(e, highlightedIndex),
-												onKeyUp: e => {
-													this.$emit('keyUp', e);
-												}
-											})
-										}}
-										{...{
-											domProps: getInputProps({
-												value: instanceValue || ''
-											})
-										}}
-									/>
-									{this.renderIcons()}
-									{this.hasCustomRenderer
-										&& this.getComponent({
-											isOpen,
-											getItemProps,
-											getItemEvents,
-											highlightedIndex
-										})}
-									{this.renderErrorComponent()}
-									{!this.hasCustomRenderer
-                  					&& isOpen ? (
-											<ul
-												class={`${suggestionsStyle} ${getClassName(
-													innerClass,
-													'list'
-												)}`}
-											>
-												{suggestionsList.slice(0, size).map((item, index) => (
-													<li
-														{...{
-															domProps: getItemProps({ item })
-														}}
-														{...{
-															on: getItemEvents({
-																item
-															})
-														}}
-														key={`${index + 1}-${
-															item.value
-														}`}
-														style={{
-															backgroundColor: this.getBackgroundColor(
-																highlightedIndex,
-																index
-															)
-														}}
-													>
-														<SuggestionItem
-															currentValue={instanceValue}
-															suggestion={item}
-														/>
-													</li>
-												))}
-												{
-													!instanceValue ? (recentSearches || []).map((sugg, index) => (
+							}) => {
+								const renderSuggestionsContainer = () => {
+									return (
+										<div>
+											{this.hasCustomRenderer
+                        && this.getComponent({
+                        	isOpen,
+                        	getItemProps,
+                        	getItemEvents,
+                        	highlightedIndex
+                        })}
+											{this.renderErrorComponent()}
+											{!this.hasCustomRenderer && isOpen ? (
+												<ul
+													class={`${suggestionsStyle} ${getClassName(
+														innerClass,
+														'list'
+													)}`}
+												>
+													{suggestionsList.slice(0, size).map((item, index) => (
 														<li
 															{...{
-																domProps: getItemProps({
-																	item: sugg
-																})
+																domProps: getItemProps({ item })
 															}}
 															{...{
 																on: getItemEvents({
-																	item: sugg
+																	item
 																})
 															}}
-															key={`${index + 1}-${sugg.value}`}
+															key={`${index + 1}-${item.value}`}
 															style={{
 																backgroundColor: this.getBackgroundColor(
 																	highlightedIndex,
 																	index
-																),
-																justifyContent: 'flex-start'
+																)
 															}}
 														>
-															<div style={{padding: '0 10px 0 0'}}>
-																<CustomSvg
-																	iconId={`${index + 1}-${sugg.value}-icon`}
-																	className={
-																		getClassName(
-																			innerClass,
-																			'recent-search-icon'
-																		) || null
-																	}
-																	icon={recentSearchesIcon}
-																	type="recent-search-icon"
-																/>
-															</div>
 															<SuggestionItem
 																currentValue={instanceValue}
-																suggestion={sugg}
+																suggestion={item}
 															/>
 														</li>
-													)) : null
-												}
-												{instanceValue && (hasPopularSuggestionsRenderer(this)
-													? this.getComponent(
-														{
-															isOpen,
-															getItemProps,
-															getItemEvents,
-															highlightedIndex
-														},
-														true
-													)
-													: (popularSuggestionsList || []).map((sugg, index) => (
-														<li
-															{...{
-																domProps: getItemProps({
-																	item: sugg
-																})
-															}}
-															{...{
-																on: getItemEvents({
-																	item: sugg
-																})
-															}}
-															key={`${index + suggestionsList.length + 1}-${sugg.value}`}
-															style={{
-																backgroundColor: this.getBackgroundColor(
-																	highlightedIndex,
-																	index + suggestionsList.length
-																),
-																justifyContent: 'flex-start'
-															}}
-														>
-															<div style={{padding: '0 10px 0 0'}}>
-																<CustomSvg
-																	iconId={`${index + 1}-${sugg.value}-icon`}
-																	className={
-																		getClassName(
-																			innerClass,
-																			'popular-search-icon'
-																		) || null
-																	}
-																	icon={popularSearchesIcon}
-																	type="popular-search-icon"
+													))}
+													{!instanceValue
+														? (recentSearches || []).map((sugg, index) => (
+															<li
+																{...{
+																	domProps: getItemProps({
+																		item: sugg
+																	})
+																}}
+																{...{
+																	on: getItemEvents({
+																		item: sugg
+																	})
+																}}
+																key={`${index + 1}-${sugg.value}`}
+																style={{
+																	backgroundColor: this.getBackgroundColor(
+																		highlightedIndex,
+																		index
+																	),
+																	justifyContent: 'flex-start'
+																}}
+															>
+																<div style={{ padding: '0 10px 0 0' }}>
+																	<CustomSvg
+																		iconId={`${index + 1}-${sugg.value}-icon`}
+																		className={
+																			getClassName(
+																				innerClass,
+																				'recent-search-icon'
+																			) || null
+																		}
+																		icon={recentSearchesIcon}
+																		type="recent-search-icon"
+																	/>
+																</div>
+																<SuggestionItem
+																	currentValue={instanceValue}
+																	suggestion={sugg}
 																/>
-															</div>
-															<SuggestionItem
-																currentValue={instanceValue}
-																suggestion={sugg}
-															/>
-														</li>
-													)))}
-											</ul>
-										) : (
-											this.renderNoSuggestionComponent()
-										)}
-								</div>
-							)
+															</li>
+														))
+														: null}
+													{instanceValue
+                            && (hasPopularSuggestionsRenderer(this)
+                            	? this.getComponent(
+                            		{
+                            			isOpen,
+                            			getItemProps,
+                            			getItemEvents,
+                            			highlightedIndex
+                            		},
+                            		true
+                            	)
+                            	: (popularSuggestionsList || []).map(
+                            		(sugg, index) => (
+                            			<li
+                            				{...{
+                            					domProps: getItemProps({
+                            						item: sugg
+                            					})
+                            				}}
+                            				{...{
+                            					on: getItemEvents({
+                            						item: sugg
+                            					})
+                            				}}
+                            				key={`${index
+                                        + suggestionsList.length
+                                        + 1}-${sugg.value}`}
+                            				style={{
+                            					backgroundColor: this.getBackgroundColor(
+                            						highlightedIndex,
+                            						index + suggestionsList.length
+                            					),
+                            					justifyContent: 'flex-start'
+                            				}}
+                            			>
+                            				<div style={{ padding: '0 10px 0 0' }}>
+                            					<CustomSvg
+                            						iconId={`${index + 1}-${
+                            							sugg.value
+                            						}-icon`}
+                            						className={
+                            							getClassName(
+                            								innerClass,
+                            								'popular-search-icon'
+                            							) || null
+                            						}
+                            						icon={popularSearchesIcon}
+                            						type="popular-search-icon"
+                            					/>
+                            				</div>
+                            				<SuggestionItem
+                            					currentValue={instanceValue}
+                            					suggestion={sugg}
+                            				/>
+                            			</li>
+                            		)
+                            	))}
+												</ul>
+											) : (
+												this.renderNoSuggestionComponent()
+											)}
+										</div>
+									);
+								};
+								return (
+									<div class={suggestionsContainer}>
+										<InputGroup>
+											{this.renderInputAddonBefore()}
+											<InputWrapper>
+												<Input
+													ref="searchInputField"
+													showIcon={showIcon}
+													showClear={showClear}
+													iconPosition={iconPosition}
+													class={getClassName(innerClass, 'input')}
+													placeholder={placeholder}
+													currentValue={instanceValue}
+													autoFocus={autoFocus}
+													{...{
+														on: getInputEvents({
+															onInput: this.onInputChange,
+															onBlur: e => {
+																this.$emit('blur', e);
+															},
+															onFocus: this.handleFocus,
+															onKeyPress: e => {
+																this.$emit('keyPress', e);
+															},
+															onKeyDown: e =>
+																this.handleKeyDown(e, highlightedIndex),
+															onKeyUp: e => {
+																this.$emit('keyUp', e);
+															}
+														})
+													}}
+													{...{
+														domProps: getInputProps({
+															value: instanceValue || ''
+														})
+													}}
+												/>
+												{this.renderIcons()}
+												{!expandSuggestionsContainer
+                          && renderSuggestionsContainer()}
+											</InputWrapper>
+											{this.renderInputAddonAfter()}
+										</InputGroup>
+										{expandSuggestionsContainer && renderSuggestionsContainer()}
+									</div>
+								);
+							}
 						}}
 					/>
 				) : (
 					<div class={suggestionsContainer}>
 						<Input
+							ref="searchInputField"
 							class={getClassName(innerClass, 'input') || ''}
 							placeholder={placeholder}
+							autoFocus={autoFocus}
 							{...{
 								on: {
 									blur: e => {
@@ -678,7 +834,14 @@ const SearchBoxWrapper = {
 					on: context.listeners,
 					props: context.props,
 					scopedSlots: {
-						default: ({ loading, error, micStatus, results, value, recentSearches }) => {
+						default: ({
+							loading,
+							error,
+							micStatus,
+							results,
+							value,
+							recentSearches
+						}) => {
 							return (
 								<SearchBox
 									loading={loading}

--- a/packages/vue-searchbox/src/components/SearchBox.jsx
+++ b/packages/vue-searchbox/src/components/SearchBox.jsx
@@ -120,7 +120,7 @@ const SearchBox = {
 		focusShortcuts: VueTypes.focusShortcuts,
 		addonBefore: VueTypes.any,
 		addonAfter: VueTypes.any,
-		expandSuggestionsContainer: { default: true, type: Boolean }
+		expandSuggestionsContainer: types.expandSuggestionsContainer
 	},
 	data() {
 		this.state = {

--- a/packages/vue-searchbox/src/components/SearchBox.jsx
+++ b/packages/vue-searchbox/src/components/SearchBox.jsx
@@ -497,7 +497,6 @@ const SearchBox = {
 
 			// for hotkeys' combinations such as 'cmd+k', 'ctrl+shft+a', etc, we use hotkeys-js
 			if (this.hotKeyCombinationsUsed) {
-				console.log('hey there', this.hotKeyCombinationsUsed);
 				this.hotkeys(
 					parseFocusShortcuts(focusShortcuts).join(','), // eslint-disable-next-line no-unused-vars
 					/* eslint-disable no-shadow */ (event, handler) => {

--- a/packages/vue-searchbox/src/styles/InputAddon.js
+++ b/packages/vue-searchbox/src/styles/InputAddon.js
@@ -1,0 +1,30 @@
+import styled from '@appbaseio/vue-emotion';
+
+const InputAddon = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  background-color: #fafafa;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  color: rgba(0, 0, 0, 0.85);
+  font-size: 14px;
+  font-weight: 400;
+  padding: 2px 11px;
+  position: relative;
+  transition: all 0.3s;
+  box-sizing: border-box;
+  overflow: hidden;
+
+  &:first-of-type {
+    border-right: none;
+  }
+  &:last-of-type {
+    border-left: none;
+  }
+`;
+
+InputAddon.defaultProps = { className: 'input-addon' };
+
+export default InputAddon;

--- a/packages/vue-searchbox/src/styles/InputGroup.js
+++ b/packages/vue-searchbox/src/styles/InputGroup.js
@@ -1,0 +1,12 @@
+import styled from '@appbaseio/vue-emotion';
+
+const InputGroup = styled('div')`
+  display: flex;
+  align-items: center;
+  height: 42px;
+  width: 100%;
+`;
+
+InputGroup.defaultProps = { className: 'input-group' };
+
+export default InputGroup;

--- a/packages/vue-searchbox/src/styles/InputWrapper.js
+++ b/packages/vue-searchbox/src/styles/InputWrapper.js
@@ -1,0 +1,8 @@
+import styled from '@appbaseio/vue-emotion';
+
+const InputWrapper = styled('div')`
+  flex: 1;
+  position: relative;
+`;
+
+export default InputWrapper;

--- a/packages/vue-searchbox/src/utils/helper.js
+++ b/packages/vue-searchbox/src/utils/helper.js
@@ -23,7 +23,7 @@ export const equals = (a, b) => {
 export const debounce = (method, delay) => {
 	clearTimeout(method._tId);
 	// eslint-disable-next-line
-	method._tId = setTimeout(() => {
+  method._tId = setTimeout(() => {
 		method();
 	}, delay);
 };
@@ -135,3 +135,73 @@ export const getCamelCase = (str = '') => {
 	const capitalString = capital.join('');
 	return capitalString || '';
 };
+
+export const isEmpty = val => !(val && val.length && Object.keys(val).length);
+
+export function isNumeric(value) {
+	return /^-?\d+$/.test(value);
+}
+
+// check if passed shortcut a key combination
+export function isHotkeyCombination(hotkey) {
+	return typeof hotkey === 'string' && hotkey.indexOf('+') !== -1;
+}
+
+// parse focusshortcuts array for key combinations
+export function isHotkeyCombinationUsed(focusShortcuts) {
+	for (let index = 0; index < focusShortcuts.length; index += 1) {
+		if (isHotkeyCombination(focusShortcuts[index])) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// used for getting correct string char from keycode passed
+// the below algebraic expression is used to get the correct ascii code out of the e.which || e.keycode returned value
+// since the keyboards doesn't understand ascii but scan codes and they differ for certain keys such as '/'
+// stackoverflow ref: https://stackoverflow.com/a/29811987/10822996
+export function getCharFromCharCode(passedCharCode) {
+	const which = passedCharCode;
+	const chrCode = which - 48 * Math.floor(which / 48);
+	return String.fromCharCode(which >= 96 ? chrCode : which);
+}
+
+// used for parsing focusshortcuts for keycodes passed as string, eg: 'ctrl+/' is same as 'ctrl+47'
+// returns focusShortcuts containing appropriate key charsas depicted on keyboards
+export function parseFocusShortcuts(focusShortcutsArray) {
+	if (isEmpty(focusShortcutsArray)) return [];
+
+	const parsedFocusShortcutsArray = [];
+	focusShortcutsArray.forEach(element => {
+		if (typeof element === 'string') {
+			if (isHotkeyCombination(element)) {
+				// splitting the combination into pieces
+				const splitCombination = element.split('+');
+				const parsedSplitCombination = [];
+				// parsedCombination would have all the keycodes converted into chars
+				let parsedCombination = '';
+				for (let i = 0; i < splitCombination.length; i += 1) {
+					if (isNumeric(splitCombination[i])) {
+						parsedSplitCombination.push(
+							getCharFromCharCode(+splitCombination[i])
+						);
+					} else {
+						parsedSplitCombination.push(splitCombination[i]);
+					}
+				}
+				parsedCombination = parsedSplitCombination.join('+');
+				parsedFocusShortcutsArray.push(parsedCombination);
+			} else if (isNumeric(element)) {
+				parsedFocusShortcutsArray.push(getCharFromCharCode(+element));
+			} else {
+				// single char shortcut, eg: '/'
+				parsedFocusShortcutsArray.push(element);
+			}
+		} else {
+			// if not a string the the shortcut is assumed to be a keycode
+			parsedFocusShortcutsArray.push(getCharFromCharCode(element));
+		}
+	});
+	return parsedFocusShortcutsArray;
+}

--- a/packages/vue-searchbox/src/utils/types.js
+++ b/packages/vue-searchbox/src/utils/types.js
@@ -87,5 +87,6 @@ export const types = {
 	sourceFields: VueTypes.arrayOf(VueTypes.string),
 	focusShortcuts: VueTypes.arrayOf(
 		VueTypes.oneOfType([VueTypes.string, VueTypes.number])
-	)
+	),
+	expandSuggestionsContainer: VueTypes.bool.def(true)
 };

--- a/packages/vue-searchbox/src/utils/types.js
+++ b/packages/vue-searchbox/src/utils/types.js
@@ -7,12 +7,12 @@ const DataField = VueTypes.shape({
 	weight: VueTypes.number
 });
 
-const reactKeyType =  VueTypes.oneOfType([
+const reactKeyType = VueTypes.oneOfType([
 	VueTypes.string,
 	VueTypes.arrayOf(VueTypes.string),
 	VueTypes.object,
-	VueTypes.arrayOf( VueTypes.object)]
-)
+	VueTypes.arrayOf(VueTypes.object)
+]);
 
 // eslint-disable-next-line
 export const types = {
@@ -81,8 +81,11 @@ export const types = {
 	reactType: VueTypes.shape({
 		and: reactKeyType,
 		or: reactKeyType,
-		not: reactKeyType,
+		not: reactKeyType
 	}),
 	sortType: VueTypes.oneOf(['asc', 'desc', 'count']),
-	sourceFields: VueTypes.arrayOf(VueTypes.string)
+	sourceFields: VueTypes.arrayOf(VueTypes.string),
+	focusShortcuts: VueTypes.arrayOf(
+		VueTypes.oneOfType([VueTypes.string, VueTypes.number])
+	)
 };


### PR DESCRIPTION
**Description** :
- Support focusShortcuts prop to focus input field using custom keyboard shortcuts.
- Support autoFocus prop for the input search field.
- Support addonBefore & addonAfter slots to render custom HTML markup before & after the input search field.
- Support expandSuggestionsContainer prop to expand/ limit the suggestions dropdown container width to the whole input wrapper/ input field.

[Notion Link](https://www.notion.so/appbase/Support-searchbox-focus-with-keyboard-shortcut-3010b391595d4d0495a65e99f9591f9a)

[Docs PR Link](https://github.com/appbaseio/Docs/pull/193)

[Loom Demo: focusShortcuts, autoFocus, expandSuggestionsContainer - props; addonBefore, addonAfter - slots](https://www.loom.com/share/968ecd2f5d5542c59bbef79e184592b3)
