### PR TITLE
fix: icon alignment condition for voice & clear

### DIFF
--- a/packages/react-searchbox/src/components/SearchBox.js
+++ b/packages/react-searchbox/src/components/SearchBox.js
@@ -735,6 +735,7 @@ class SearchBox extends React.Component {
       autosuggest,
       showIcon,
       showClear,
+      showVoiceSearch,
       iconPosition,
       placeholder,
       onBlur,
@@ -780,6 +781,7 @@ class SearchBox extends React.Component {
                       ref={this.searchInputField}
                       showIcon={showIcon}
                       showClear={showClear}
+                      showVoiceSearch={showVoiceSearch}
                       iconPosition={iconPosition}
                       {...getInputProps({
                         className: getClassName(innerClass, 'input'),
@@ -845,6 +847,7 @@ class SearchBox extends React.Component {
                   iconPosition={iconPosition}
                   showIcon={showIcon}
                   showClear={showClear}
+                  showVoiceSearch={showVoiceSearch}
                 />
                 {this.renderIcons()}
               </InputWrapper>

--- a/packages/react-searchbox/src/styles/Input.js
+++ b/packages/react-searchbox/src/styles/Input.js
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 const input = css`
   width: 100%;
   height: 42px;
-  line-height:42px;
+  line-height: 42px;
   padding: 8px 12px;
   border: 1px solid #ccc;
   background-color: #fafafa;
@@ -20,65 +20,64 @@ const input = css`
 const Input = styled.input`
   ${input}
 
+  ${props =>
+    props.showIcon &&
+    props.iconPosition === 'left' &&
+    css`
+      padding-left: 36px;
+    `};
 
-	${props =>
-		props.showIcon
-		&& props.iconPosition === 'left'
-		&& css`
-			padding-left: 36px;
-		`};
+  ${props =>
+    props.showIcon &&
+    props.iconPosition === 'right' &&
+    css`
+      padding-right: 36px;
+    `};
 
-	${props =>
-		props.showIcon
-		&& props.iconPosition === 'right'
-		&& css`
-			padding-right: 36px;
-		`};
-
-	${props =>
-		// for clear icon
-		props.showClear
-		&& css`
-			padding-right: 36px;
-		`};
-		${props =>
-			// for voice search icon
-			props.showVoiceSearch
-			&& css`
-					padding-right: 36px;
-				`};
-	${props =>
-		// for clear icon with search icon
-		props.showClear
-		&& props.showIcon
-		&& props.iconPosition === 'right'
-		&& css`
-			padding-right: 66px;
-		`};
-		${props =>
-			// for voice search icon with clear icon
-			props.showVoiceSearch
-			&& props.showIcon
-			&& css`
-						padding-right: 66px;
-					`};
-		${props =>
-			// for voice search icon with search icon
-			props.showVoiceSearch
-			&& props.showIcon
-			&& props.iconPosition === 'right'
-			&& css`
-				padding-right: 66px;
-				`};
-			${props =>
-			// for clear icon with search icon and voice search
-			props.showClear
-			&& props.showIcon && props.showVoiceSearch
-			&& props.iconPosition === 'right'
-			&& css`
-					padding-right: 90px;
-				`};
-
+  ${props =>
+    // for clear icon
+    props.showClear &&
+    css`
+      padding-right: 36px;
+    `};
+  ${props =>
+    // for voice search icon
+    props.showVoiceSearch &&
+    css`
+      padding-right: 36px;
+    `};
+  ${props =>
+    // for clear icon with search icon
+    props.showClear &&
+    props.showIcon &&
+    props.iconPosition === 'right' &&
+    css`
+      padding-right: 66px;
+    `};
+  ${props =>
+    // for voice search icon with clear icon
+    props.showVoiceSearch &&
+    props.showClear &&
+    css`
+      padding-right: 66px;
+    `};
+  ${props =>
+    // for voice search icon with search icon
+    props.showVoiceSearch &&
+    props.showIcon &&
+    props.iconPosition === 'right' &&
+    css`
+      padding-right: 66px;
+    `};
+  ${props =>
+    // for clear icon with search icon and voice search
+    props.showClear &&
+    props.showIcon &&
+    props.showVoiceSearch &&
+    props.iconPosition === 'right' &&
+    css`
+      padding-right: 90px;
+    `};
 `;
 
 export default Input;

--- a/packages/react-searchbox/src/styles/Input.js
+++ b/packages/react-searchbox/src/styles/Input.js
@@ -52,7 +52,7 @@ const Input = styled.input`
     props.showIcon &&
     props.iconPosition === 'right' &&
     css`
-      padding-right: 66px;
+      padding-right: 61px;
     `};
   ${props =>
     // for voice search icon with clear icon
@@ -67,7 +67,7 @@ const Input = styled.input`
     props.showIcon &&
     props.iconPosition === 'right' &&
     css`
-      padding-right: 66px;
+      padding-right: 62px;
     `};
   ${props =>
     // for clear icon with search icon and voice search

--- a/packages/vue-searchbox/src/components/SearchBox.jsx
+++ b/packages/vue-searchbox/src/components/SearchBox.jsx
@@ -572,6 +572,7 @@ const SearchBox = {
 			innerClass,
 			showIcon,
 			showClear,
+	  		showVoiceSearch,
 			iconPosition,
 			title,
 			defaultSuggestions,
@@ -768,6 +769,7 @@ const SearchBox = {
 													ref="searchInputField"
 													showIcon={showIcon}
 													showClear={showClear}
+													showVoiceSearch={showVoiceSearch}
 													iconPosition={iconPosition}
 													class={getClassName(innerClass, 'input')}
 													placeholder={placeholder}
@@ -847,6 +849,7 @@ const SearchBox = {
 									iconPosition={iconPosition}
 									showIcon={showIcon}
 									showClear={showClear}
+									showVoiceSearch={showVoiceSearch}
 									innerRef={innerRef}
 								/>
 								{this.renderIcons()}

--- a/packages/vue-searchbox/src/styles/Input.js
+++ b/packages/vue-searchbox/src/styles/Input.js
@@ -44,7 +44,7 @@ const Input = styled('input')`
 	// for voice search icon
 		props.showVoiceSearch
     && css`
-      padding-right: 32px;
+      padding-right: 36px;
     `};
 
   ${props =>
@@ -66,8 +66,8 @@ const Input = styled('input')`
     `};
   ${props =>
 	// for voice search icon with clear icon
-		props.showVoiceSearch
-    && props.showIcon
+		props.showClear
+    && props.showVoiceSearch
     && css`
       padding-right: 66px;
     `};


### PR DESCRIPTION
**Issue Type**: `BUG`

**Description**: 
- Added missing `showVoiceSearch` prop for `<Input />`.
- Corrected name for the condition when clear and voice search icons are adjacently shown.
- Corrected padding figure for vue.

[Demo  -Vue](https://www.loom.com/share/6defca1539ef4072b4743275917219a7)
[Demo -React](https://www.loom.com/share/2ed2a16ab1f1451eb00cb80f1bb8406b)

[Loom: PR Self Review](https://www.loom.com/share/3b2d855212634a2fa82ca44609b0644d)


[Follow up PR](https://github.com/appbaseio/searchbox/pull/83)