### PR TITLE
fix(react): added null check in suggestion select method

### DIFF
--- a/packages/react-searchbox/src/components/SearchBox.js
+++ b/packages/react-searchbox/src/components/SearchBox.js
@@ -338,6 +338,11 @@ class SearchBox extends React.Component {
 
   onSuggestionSelected = suggestion => {
     if (!suggestion) {
+      this.componentInstance.setValue('', {
+        triggerDefaultQuery: true,
+        triggerCustomQuery: true,
+        stateChanges: true
+      });
       return;
     }
     this.setValue({

--- a/packages/react-searchbox/src/components/SearchBox.js
+++ b/packages/react-searchbox/src/components/SearchBox.js
@@ -337,13 +337,16 @@ class SearchBox extends React.Component {
   };
 
   onSuggestionSelected = suggestion => {
+    if (!suggestion) {
+      return;
+    }
     this.setValue({
-      value: suggestion && suggestion.value,
+      value: suggestion.value,
       isOpen: false,
       triggerCustomQuery: true
     });
     this.triggerClickAnalytics(
-      suggestion && suggestion._click_id,
+      suggestion._click_id,
       true,
       suggestion.source && suggestion.source._id
     );


### PR DESCRIPTION
**ISSUE TYPE:** `BUG`

**Description:** Null-check in the `onSuggestionSelected` method was missing and thus breaking the UI for some edge cases.

**Replication:** 

1.  Go to  [app](https://z9t3s.csb.app/).
2. Type in a query and select one suggestion from the dropdown.
3. After that, press the `ESC` button, you would see the UI breaking.

[Loom](https://www.loom.com/share/4e0930f7041c4ad386868b29c34b6cd1)

