### PR TITLE
fix: close suggestions dropdown on escape press

### DIFF
--- a/packages/react-searchbox/src/components/SearchBox.js
+++ b/packages/react-searchbox/src/components/SearchBox.js
@@ -518,6 +518,9 @@ class SearchBox extends React.Component {
       });
       this.onValueSelected(event.target.value, causes.ENTER_PRESS);
     }
+    if (event.key === 'Escape') {
+      this.setState({ isOpen: false });
+    }
 
     if (this.props.onKeyDown) {
       this.props.onKeyDown(this.componentInstance, event);


### PR DESCRIPTION
**Description:** The PR includes the detection of `esc` button press and closing of the suggestions dropdown as the default behaviour.

Libraries Affected: 
- React-SearchBox

[Loom: Code + App](https://www.loom.com/share/c4e585dce9214faeadf09c1c24280df7)