### PR TITLE
feat(react-vue): add enter button to Searchbox component

### DIFF
--- a/packages/react-searchbox/src/components/SearchBox.js
+++ b/packages/react-searchbox/src/components/SearchBox.js
@@ -143,9 +143,10 @@ class SearchBox extends React.Component {
     if (!this.componentInstance.value && defaultSuggestions) {
       return defaultSuggestions;
     }
-    const suggestions = this.componentInstance.mongodb
-      ? this.componentInstance.suggestions
-      : this.componentInstance?.results?.data ?? [];
+    const suggestions =
+      (this.componentInstance.mongodb
+        ? this.componentInstance.suggestions
+        : this.componentInstance?.results?.data) ?? [];
     return suggestions;
   }
 
@@ -410,7 +411,7 @@ class SearchBox extends React.Component {
   };
 
   renderEnterButtonElement = () => {
-    const { enterButton, renderEnterButton } = this.props;
+    const { enterButton, renderEnterButton, innerClass } = this.props;
 
     const enterButtonOnClick = () => {
       this.triggerCustomQuery();
@@ -427,11 +428,7 @@ class SearchBox extends React.Component {
 
         return (
           <Button
-            style={{
-              borderTopLeftRadius: 0,
-              borderBottomLeftRadius: 0
-            }}
-            className="enter-btn"
+            className={`enter-btn ${getClassName(innerClass, 'enterButton')}`}
             primary
             onClick={enterButtonOnClick}
           >
@@ -441,9 +438,7 @@ class SearchBox extends React.Component {
       };
 
       return (
-        <div style={{ height: '100%' }} className="enter-button-wrapper">
-          {getEnterButtonMarkup()}
-        </div>
+        <div className="enter-button-wrapper">{getEnterButtonMarkup()}</div>
       );
     }
 

--- a/packages/react-searchbox/src/components/SearchBox.js
+++ b/packages/react-searchbox/src/components/SearchBox.js
@@ -56,7 +56,7 @@ import causes from '../utils/causes';
 import CustomSvg from '../styles/CustomSvg';
 import AutofillSvg from '../styles/AutofillSvg';
 import { arrayOf } from 'prop-types';
-import SearchSvg from '../styles/SearchSvg';
+import Button from '../styles/Button';
 
 class SearchBox extends React.Component {
   static contextType = SearchContext;
@@ -244,7 +244,7 @@ class SearchBox extends React.Component {
   };
 
   setValue = ({ value, isOpen = true, category = undefined, ...rest }) => {
-    const { onChange, debounce, autosuggest } = this.props;
+    const { onChange, debounce, autosuggest, enterButton } = this.props;
     if (!value && autosuggest && rest.cause !== causes.CLEAR_VALUE) {
       this.componentInstance.triggerDefaultQuery();
     }
@@ -272,7 +272,7 @@ class SearchBox extends React.Component {
       });
       if (autosuggest) {
         debounceFunc(this.triggerDefaultQuery, debounce);
-      } else {
+      } else if (!enterButton) {
         debounceFunc(this.triggerCustomQuery, debounce);
       }
     } else {
@@ -282,7 +282,7 @@ class SearchBox extends React.Component {
         stateChanges: true
       });
 
-      if (!autosuggest) {
+      if (!autosuggest && !enterButton) {
         this.triggerCustomQuery();
       }
     }
@@ -404,6 +404,47 @@ class SearchBox extends React.Component {
     const { addonAfter } = this.props;
     if (addonAfter) {
       return <InputAddon>{addonAfter}</InputAddon>;
+    }
+
+    return null;
+  };
+
+  renderEnterButtonElement = () => {
+    const { enterButton, renderEnterButton } = this.props;
+
+    const enterButtonOnClick = () => {
+      this.triggerCustomQuery();
+      this.setState({
+        isOpen: false
+      });
+    };
+
+    if (enterButton) {
+      const getEnterButtonMarkup = () => {
+        if (typeof renderEnterButton === 'function') {
+          return renderEnterButton(enterButtonOnClick);
+        }
+
+        return (
+          <Button
+            style={{
+              borderTopLeftRadius: 0,
+              borderBottomLeftRadius: 0
+            }}
+            className="enter-btn"
+            primary
+            onClick={enterButtonOnClick}
+          >
+            Search
+          </Button>
+        );
+      };
+
+      return (
+        <div style={{ height: '100%' }} className="enter-button-wrapper">
+          {getEnterButtonMarkup()}
+        </div>
+      );
     }
 
     return null;
@@ -808,6 +849,7 @@ class SearchBox extends React.Component {
                       })}
                   </InputWrapper>
                   {this.renderInputAddonAfter()}
+                  {this.renderEnterButtonElement()}
                 </InputGroup>
 
                 {this.props.expandSuggestionsContainer &&
@@ -849,6 +891,7 @@ class SearchBox extends React.Component {
                 {this.renderIcons()}
               </InputWrapper>
               {this.renderInputAddonAfter()}
+              {this.renderEnterButtonElement()}
             </InputGroup>
           </div>
         )}
@@ -940,7 +983,9 @@ SearchBox.propTypes = {
   enableRecentSearches: bool,
   enableRecentSuggestions: bool,
   applyStopwords: bool,
-  stopwords: arrayOf(string)
+  stopwords: arrayOf(string),
+  enterButton: bool,
+  renderEnterButton: func
 };
 
 SearchBox.defaultProps = {
@@ -977,7 +1022,8 @@ SearchBox.defaultProps = {
   urlField: '',
   rankFeature: undefined,
   categoryField: '',
-  categoryValue: ''
+  categoryValue: '',
+  enterButton: false
 };
 
 export default props => (

--- a/packages/react-searchbox/src/styles/Button.js
+++ b/packages/react-searchbox/src/styles/Button.js
@@ -45,6 +45,11 @@ const Button = styled('a')`
   }
 
   ${props => (props.primary ? primary : null)};
+
+  &.enter-btn {
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+  }
 `;
 
 export default Button;

--- a/packages/react-searchbox/src/styles/Button.js
+++ b/packages/react-searchbox/src/styles/Button.js
@@ -1,0 +1,50 @@
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
+const primary = () => css`
+  background-color: #0b6aff;
+  color: #fff;
+
+  &:hover {
+    background-color: #0b6aff;
+    filter: brightness(0.9);
+  }
+
+  &:active {
+    background-color: #0b6aff;
+    filter: brightness(1.1);
+  }
+`;
+
+const Button = styled('a')`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 3px;
+  border: 1px solid transparent;
+  min-height: 30px;
+  word-wrap: break-word;
+  padding: 5px 12px;
+  line-height: 1.2rem;
+  background-color: #eee;
+  color: #000;
+  cursor: pointer;
+  user-select: none;
+  transition: all 0.3s ease;
+  font-weight: 500;
+
+  &:hover,
+  &:focus {
+    background-color: #ccc;
+  }
+
+  &:focus {
+    outline: 0;
+    border-color: rgba(#0b6aff, 0.6);
+    box-shadow: 0 0 0 2px rgba(#0b6aff, 0.3);
+  }
+
+  ${props => (props.primary ? primary : null)};
+`;
+
+export default Button;

--- a/packages/react-searchbox/src/styles/InputGroup.js
+++ b/packages/react-searchbox/src/styles/InputGroup.js
@@ -5,6 +5,10 @@ const InputGroup = styled.div`
   align-items: center;
   height: 42px;
   width: 100%;
+
+  .enter-button-wrapper {
+    height: 100%;
+  }
 `;
 
 InputGroup.defaultProps = { className: 'input-group' };

--- a/packages/vue-searchbox/src/components/SearchBox.jsx
+++ b/packages/vue-searchbox/src/components/SearchBox.jsx
@@ -31,6 +31,7 @@ import Icons from './Icons.jsx';
 import causes from '../utils/causes';
 import CustomSvg from '../styles/CustomSvg';
 import AutofillSvg from '../styles/AutofillSvg';
+import Button from '../styles/Button';
 
 const SearchBox = {
 	name: 'search-box',
@@ -136,7 +137,9 @@ const SearchBox = {
 		stopwords: VueTypes.arrayOf(VueTypes.string),
 		mongodb: VueTypes.object,
 		autocompleteField: types.dataField,
-		highlightConfig: VueTypes.object
+		highlightConfig: VueTypes.object,
+		enterButton: VueTypes.bool.def(false),
+		renderEnterButton: VueTypes.any
 	},
 	data() {
 		this.state = {
@@ -212,7 +215,7 @@ const SearchBox = {
 				? this.getComponentInstance().suggestions
 				: this.getComponentInstance()?.results?.data;
 
-			return suggestions;
+			return suggestions ?? [];
 		},
 		_applySetter(prev, next, setterFunc) {
 			if (!equals(prev, next)) {
@@ -344,7 +347,7 @@ const SearchBox = {
 						componentInstance.clearResults();
 					}
 					debounceFunc(this.triggerDefaultQuery, debounce);
-				} else {
+				} else if (!this.enterButton) {
 					debounceFunc(this.triggerCustomQuery, debounce);
 				}
 				if (rest.triggerCustomQuery) {
@@ -354,10 +357,10 @@ const SearchBox = {
 				componentInstance.setValue(value, {
 					triggerCustomQuery: rest.triggerCustomQuery,
 					triggerDefaultQuery: this.autosuggest,
-					stateChanges: true					
+					stateChanges: true
 				});
 
-				if (!this.autosuggest) {
+				if (!this.autosuggest && !this.enterButton) {
 					this.triggerCustomQuery();
 				}
 			}
@@ -399,6 +402,40 @@ const SearchBox = {
 			const { addonAfter } = this.$scopedSlots;
 			if (addonAfter) {
 				return <InputAddon>{addonAfter()}</InputAddon>;
+			}
+
+			return null;
+		},
+		renderEnterButtonElement() {
+			const { enterButton, innerClass } = this.$props;
+			const { renderEnterButton } = this.$scopedSlots;
+			const enterButtonOnClick = () => {
+				this.isOpen = false;
+				this.triggerCustomQuery();
+			};
+
+			if (enterButton) {
+				const getEnterButtonMarkup = () => {
+					if (renderEnterButton) {
+						return renderEnterButton(enterButtonOnClick);
+					}
+
+					return (
+						<Button
+							class={`enter-btn ${getClassName(innerClass, 'enterButton')}`}
+							primary
+							onClick={enterButtonOnClick}
+						>
+             				Search
+						</Button>
+					);
+				};
+
+				return (
+					<div class="enter-button-wrapper">
+						{getEnterButtonMarkup()}
+					</div>
+				);
 			}
 
 			return null;
@@ -777,6 +814,7 @@ const SearchBox = {
                           && renderSuggestionsContainer()}
 											</InputWrapper>
 											{this.renderInputAddonAfter()}
+											{this.renderEnterButtonElement()}
 										</InputGroup>
 										{expandSuggestionsContainer && renderSuggestionsContainer()}
 									</div>
@@ -829,6 +867,7 @@ const SearchBox = {
 								{this.renderIcons()}
 							</InputWrapper>
 							{this.renderInputAddonAfter()}
+							{this.renderEnterButtonElement()}
 						</InputGroup>
 					</div>
 				)}

--- a/packages/vue-searchbox/src/styles/Button.js
+++ b/packages/vue-searchbox/src/styles/Button.js
@@ -1,0 +1,54 @@
+import styled, { css } from '@appbaseio/vue-emotion';
+
+const primary = () => css`
+  background-color: #0b6aff;
+  color: #fff;
+
+  &:hover {
+    background-color: #0b6aff;
+    filter: brightness(0.9);
+  }
+
+  &:active {
+    background-color: #0b6aff;
+    filter: brightness(1.1);
+  }
+`;
+
+const Button = styled('a')`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 3px;
+  border: 1px solid transparent;
+  min-height: 30px;
+  word-wrap: break-word;
+  padding: 5px 12px;
+  line-height: 1.2rem;
+  background-color: #eee;
+  color: #000;
+  cursor: pointer;
+  user-select: none;
+  transition: all 0.3s ease;
+  font-weight: 500;
+
+  &:hover,
+  &:focus {
+    background-color: #ccc;
+  }
+
+  &:focus {
+    outline: 0;
+    border-color: rgba(#0b6aff, 0.6);
+    box-shadow: 0 0 0 2px rgba(#0b6aff, 0.3);
+  }
+
+  ${props => (props.primary ? primary : null)};
+
+  &.enter-btn {
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+  }
+`;
+
+export default Button;

--- a/packages/vue-searchbox/src/styles/InputGroup.js
+++ b/packages/vue-searchbox/src/styles/InputGroup.js
@@ -5,6 +5,10 @@ const InputGroup = styled('div')`
   align-items: center;
   height: 42px;
   width: 100%;
+
+  .enter-button-wrapper{
+    height: 100%;
+  }
 `;
 
 InputGroup.defaultProps = { className: 'input-group' };


### PR DESCRIPTION
**PR Type** `Feature` 🌟 

**Description** The PR adds support for `enterButton` and `renderEnterButton` props for rendering a search button beside the search-box input, which would only update results (trigger custom query) when the button is pressed.

**Affected Libs**
- React
  - [🎥  Loom](https://www.loom.com/share/76f0c3accffc473c850c0fd2fc8f363f) 
- Vue
  - [🎥  Loom](https://www.loom.com/share/5087e38b81034fca9e8d2a3cfb634ccc)
  
**Related PR(s)** 
- https://github.com/appbaseio/Docs/pull/305

