### PR TITLE
fix(react-vue): change innerClass key from camelCase to kebab-case

### DIFF
--- a/packages/react-searchbox/src/components/SearchBox.js
+++ b/packages/react-searchbox/src/components/SearchBox.js
@@ -429,7 +429,7 @@ class SearchBox extends React.Component {
 
         return (
           <Button
-            className={`enter-btn ${getClassName(innerClass, 'enterButton')}`}
+            className={`enter-btn ${getClassName(innerClass, 'enter-button')}`}
             primary
             onClick={enterButtonOnClick}
           >

--- a/packages/vue-searchbox/src/components/SearchBox.jsx
+++ b/packages/vue-searchbox/src/components/SearchBox.jsx
@@ -422,7 +422,7 @@ const SearchBox = {
 
 					return (
 						<Button
-							class={`enter-btn ${getClassName(innerClass, 'enterButton')}`}
+							class={`enter-btn ${getClassName(innerClass, 'enter-button')}`}
 							primary
 							onClick={enterButtonOnClick}
 						>


### PR DESCRIPTION
**PR Type** `Fix`

**Description** The PR changes the camelCase format of `enterButton` **innerClass** prop key to kebab-case format. i.e., `enter-button`.

Refer to the below commits for associated docs changes:
- https://github.com/appbaseio/Docs/pull/305/commits/b5054c60d74ba4748069c63cbd2cd3ec3acd0b75
- https://github.com/appbaseio/Docs/pull/265/commits/2fdf239b3bf5814874fefe2eb0fff1752e33d7e0